### PR TITLE
fix :  bbox 계산후 화면 렌더링 시 비율 고려하도록 수정

### DIFF
--- a/myeongsung/app/schemas/job_dto.py
+++ b/myeongsung/app/schemas/job_dto.py
@@ -33,6 +33,9 @@ class Citation(BaseModel):
     source_url: Optional[str] = Field(None, description="원본 위치로 이동하는 하이퍼링크 (웹일 경우 Text Fragment 포함)")
     bbox: Optional[List[float]] = Field(None, description="선택 영역 좌표 [x1, y1, x2, y2]")
     element_id: Optional[int] = Field(None, description="내부 매핑용 요소 ID")
+    page_width: Optional[float] = Field(None, description="원본 페이지 너비")
+    page_height: Optional[float] = Field(None, description="원본 페이지 높이")
+
 
 
 

--- a/myeongsung/app/services/pdf_analysis_service.py
+++ b/myeongsung/app/services/pdf_analysis_service.py
@@ -32,8 +32,14 @@ def analyze_job_pdf(file_content: bytes) -> JobPostingCreate:
     extracted_content = []
     element_map = {} # ID로 요소 정보를 찾기 위한 맵
     
+    # Upstage 응답에서 페이지별 원본 크기 추출
+    page_dimensions = {}
+    for pg in result.get("pages", []):
+        page_dimensions[pg.get("page")] = {"width": pg.get("width"), "height": pg.get("height")}
+
     for idx, element in enumerate(result.get("elements", [])):
         page_num = element.get("page")
+
         category = element.get("category")
         content = element.get("content", {}).get("text", "")
         
@@ -61,9 +67,15 @@ def analyze_job_pdf(file_content: bytes) -> JobPostingCreate:
     llm = ChatOpenAI(model="gpt-4o-mini", temperature=0)
     
     prompt = ChatPromptTemplate.from_messages([
-        ("system", "당신은 채용 공고 분석 전문가입니다. 주어진 PDF 파싱 내용(ID 및 페이지 번호 포함)을 면밀히 분석하여 정보를 추출하세요. 특히 'citations' 필드에는 해당 정보의 근거가 된 'element_id'와 'page', 'content'를 정확히 입력하여 NotebookLM과 같은 출처 기능을 제공해야 합니다."),
+        ("system", (
+            "당신은 채용 공고 분석 전문가입니다. 주어진 PDF 파싱 내용(ID 및 페이지 번호 포함)을 면밀히 분석하여 정보를 추출하세요.\n"
+            "규칙 1: 'citations' 필드에는 해당 정보의 근거가 된 'element_id', 'page', 'content'를 정확히 입력하세요.\n"
+            "규칙 2: **중요** 'citations'에 포함된 정보는 반드시 대응하는 메인 필드(예: company_name, qualifications 등)에도 동일하게 값이 채워져야 합니다.\n"
+            "규칙 3: 해당하는 정보가 명확하지 않다면 null을 사용하되, 출처가 있는 정보는 절대로 null이 되어서는 안 됩니다."
+        )),
         ("user", "다음 PDF 분석 내용을 바탕으로 채용 정보와 출처(Citations)를 추출해주세요:\n\n{content}")
     ])
+
     
     chain = prompt | llm.with_structured_output(JobPostingCreate)
     
@@ -98,6 +110,13 @@ def analyze_job_pdf(file_content: bytes) -> JobPostingCreate:
                         if xs and ys:
                             # [x1, y1, x2, y2] 형태로 정규화하여 반환
                             citation.bbox = [float(min(xs)), float(min(ys)), float(max(xs)), float(max(ys))]
+                            
+                            # 페이지 원본 크기 정보 추가 (BBox 보정용)
+                            dim = page_dimensions.get(citation.page)
+                            if dim:
+                                citation.page_width = dim["width"]
+                                citation.page_height = dim["height"]
+
                 
                 # 페이지 이동 링크
                 if citation.page > 0:

--- a/myeongsung/app/services/pdf_analysis_service.py
+++ b/myeongsung/app/services/pdf_analysis_service.py
@@ -108,14 +108,22 @@ def analyze_job_pdf(file_content: bytes) -> JobPostingCreate:
                             ys = [v for i, v in enumerate(raw_coords) if i % 2 != 0]
                         
                         if xs and ys:
-                            # [x1, y1, x2, y2] 형태로 정규화하여 반환
-                            citation.bbox = [float(min(xs)), float(min(ys)), float(max(xs)), float(max(ys))]
-                            
-                            # 페이지 원본 크기 정보 추가 (BBox 보정용)
+                            # 페이지 원본 크기 정보 가져오기
                             dim = page_dimensions.get(citation.page)
-                            if dim:
+                            if dim and dim["width"] > 0 and dim["height"] > 0:
+                                # [x1, y1, x2, y2]를 0~1 사이의 비율로 정규화하여 반환
+                                citation.bbox = [
+                                    float(min(xs)) / dim["width"],
+                                    float(min(ys)) / dim["height"],
+                                    float(max(xs)) / dim["width"],
+                                    float(max(ys)) / dim["height"]
+                                ]
                                 citation.page_width = dim["width"]
                                 citation.page_height = dim["height"]
+                            else:
+                                # 크기 정보가 없으면 절대 좌표 유지
+                                citation.bbox = [float(min(xs)), float(min(ys)), float(max(xs)), float(max(ys))]
+
 
                 
                 # 페이지 이동 링크

--- a/myeongsung/app_streamlit.py
+++ b/myeongsung/app_streamlit.py
@@ -16,22 +16,60 @@ analysis_mode = st.sidebar.selectbox("분석 모드 선택", ["PDF 분석", "URL
 api_base_url = st.sidebar.text_input("API 서버 주소", "http://127.0.0.1:8001/api/v1")
 
 # --- 유틸리티 함수 ---
-def draw_bbox(image, bbox, label=None):
-    """이미지 위에 bbox를 그립니다."""
+def draw_bbox(image, bbox, citation, label=None):
+    """이미지 위에 bbox를 그리며, 정규화된 좌표(0-1)와 픽셀 좌표를 모두 대응합니다."""
+    img_w, img_h = image.size
+    
+    # 1. 정규화 여부 확인 (모든 값이 1.1 이하이면 0~1 사이의 비율로 간주)
+    is_normalized = all(v <= 1.1 for v in bbox)
+    
+    if is_normalized:
+        # 0~1 사이의 비율인 경우 -> 이미지 크기를 직접 곱함
+        scaled_bbox = [
+            bbox[0] * img_w,
+            bbox[1] * img_h,
+            bbox[2] * img_w,
+            bbox[3] * img_h
+        ]
+    else:
+        # 절대 좌표(Point/Pixel)인 경우 -> 기존 스케일 보정 로직 사용
+        orig_w = citation.get("page_width") or img_w
+        orig_h = citation.get("page_height") or img_h
+        scale_x = img_w / orig_w
+        scale_y = img_h / orig_h
+        scaled_bbox = [
+            bbox[0] * scale_x,
+            bbox[1] * scale_y,
+            bbox[2] * scale_x,
+            bbox[3] * scale_y
+        ]
+    
+    # 디버깅용 로그
+    st.write(f"🔍 **Debug BBox**: {'Normalized' if is_normalized else 'Absolute'} {bbox} -> Scaled {scaled_bbox}")
+    
     draw = ImageDraw.Draw(image)
-    # bbox format: [x1, y1, x2, y2]
-    draw.rectangle(bbox, outline="red", width=3)
+    draw.rectangle(scaled_bbox, outline="#FF69B4", width=5)
     if label:
-        draw.text((bbox[0], bbox[1]-10), label, fill="red")
+        draw.text((scaled_bbox[0], scaled_bbox[1]-15), label, fill="#FF69B4")
     return image
 
+
+
+
 def render_pdf_page(pdf_bytes, page_num):
-    """PDF 특정 페이지를 이미지로 렌더링합니다."""
+    """PDF 특정 페이지를 이미지로 렌더링하고 원본 크기 정보를 함께 반환합니다."""
     doc = fitz.open(stream=pdf_bytes, filetype="pdf")
-    page = doc.load_page(page_num - 1)  # 0-indexed
+    page = doc.load_page(page_num - 1)
+    
+    # 원본 페이지 크기 (Point 단위)
+    pdf_size = (page.rect.width, page.rect.height)
+    
+    # 렌더링 (DPI를 높여서 더 선명하게 볼 수도 있음, 여기서는 1.0배율)
     pix = page.get_pixmap()
     img = Image.frombytes("RGB", [pix.width, pix.height], pix.samples)
-    return img
+    
+    return img, pdf_size
+
 
 # --- 메인 로직 ---
 if analysis_mode == "PDF 분석":
@@ -122,10 +160,16 @@ if "analysis_result" in st.session_state:
             
             # PDF 시각화
             if analysis_mode == "PDF 분석" and "pdf_bytes" in st.session_state:
-                page_img = render_pdf_page(st.session_state["pdf_bytes"], cit["page"])
+                page_img, pdf_size = render_pdf_page(st.session_state["pdf_bytes"], cit["page"])
                 if cit.get("bbox"):
-                    page_img = draw_bbox(page_img, cit["bbox"], cit["field"])
-                st.image(page_img, caption=f"Page {cit['page']} 분석 결과", use_container_width=True)
+                    page_img = draw_bbox(page_img, cit["bbox"], cit, cit["field"])
+                    st.image(page_img, caption=f"Page {cit['page']} 분석 결과", width="stretch")
+                else:
+                    st.warning("⚠️ 이 출처에 대한 좌표 정보(bbox)가 결과에 포함되지 않았습니다.")
+                    st.image(page_img, caption=f"Page {cit['page']} (좌표 없음)", width="stretch")
+
+
+
             
             # 이미지 시각화
             elif analysis_mode == "이미지 분석" and "image_bytes_list" in st.session_state:
@@ -134,8 +178,9 @@ if "analysis_result" in st.session_state:
                     img = Image.open(io.BytesIO(st.session_state["image_bytes_list"][img_idx]))
                     if cit.get("bbox"):
                         # Gemini bbox는 보통 정규화되어 있을 수 있으므로 처리 필요 (현재는 Upstage 스타일 좌표 가정)
-                        img = draw_bbox(img, cit["bbox"], cit["field"])
-                    st.image(img, caption=f"이미지 {cit['page']} 분석 결과", use_container_width=True)
+                        img = draw_bbox(img, cit["bbox"], cit, cit["field"])
+                    st.image(img, caption=f"이미지 {cit['page']} 분석 결과", width="stretch")
+
             
             # URL은 링크로 대체
             else:


### PR DESCRIPTION
### 작업 내용 
<img width="464" height="268" alt="image" src="https://github.com/user-attachments/assets/92bd55dc-78f1-47ca-afef-11e64c49f940" />


- [x]  화면 사이즈에 맞게 정규화한 bbox 값 반환 ([왼쪽 위 x, 왼쪽 위 y, 오른쪽 아래 x, 오른쪽 아래 y] 형식)
