### PR TITLE
fix : 짧은 경험 유사도 분석 로직 수정 및 API 추가 

### DIFF
--- a/myeongsung/app/api/router.py
+++ b/myeongsung/app/api/router.py
@@ -12,7 +12,16 @@ from fastapi import APIRouter, UploadFile, File, Form, HTTPException, Background
 from pydantic import ValidationError
 
 from app.schemas.job_dto import JobPostingCreate, UrlAnalysisRequest
-from app.schemas.resume_dto import ExperienceExtractionResponse, PlacementResponse, Step1ExtractionResponse, ExperienceSummary, Step2ExtractionResponse
+from app.schemas.resume_dto import (
+    ExperienceExtractionResponse,
+    MergeCheckRequest,
+    MergeCheckResponse,
+    MergeExperiencePayload,
+    PlacementResponse,
+    Step1ExtractionResponse,
+    ExperienceSummary,
+    Step2ExtractionResponse,
+)
 
 from app.services.resume_service import create_workflow, parse_and_validate_experiences
 from app.services.job_analysis_service import analyze_job_url
@@ -29,6 +38,7 @@ from app.services.experience_extraction_service import (
     extract_step2_from_url,
     extract_step2_from_pdf,
 )
+from app.services.experience_merge_service import apply_merge_results_to_step2, check_merge_candidates
 from app.services.eval_service import log_evaluation
 
 
@@ -165,6 +175,7 @@ async def extract_experiences_step2(
     url: Optional[str] = Form(None, description="자소서/포트폴리오 웹페이지 URL (원문 중 단 하나만 입력해도 됨)"),
     text: Optional[str] = Form(None, description="자소서/포트폴리오 텍스트 원문 (원문 중 단 하나만 입력해도 됨)"),
     selected_experiences: str = Form(..., description="1차 추출에서 사용자가 남긴 경험 리스트 (JSON 문자열)"),
+    existing_experiences: Optional[str] = Form(None, description="현재 사용자의 저장된 경험 전체 (JSON 문자열, 병합 후보 검사 용도)"),
 ):
     """
     원문과 사용자가 선택한 1차 경험 목록을 받아, 각 경험의 소분류에 맞는 상세 정보(basic_info)를 추출합니다.
@@ -186,16 +197,45 @@ async def extract_experiences_step2(
     except Exception as e:
         raise HTTPException(status_code=400, detail=f"selected_experiences JSON 파싱 오류: {str(e)}")
 
+    existing_exp_list: List[MergeExperiencePayload] = []
+    if existing_experiences and existing_experiences.strip():
+        try:
+            raw_existing_experiences = json.loads(existing_experiences)
+            from pydantic import TypeAdapter
+            existing_exp_list = TypeAdapter(List[MergeExperiencePayload]).validate_python(raw_existing_experiences)
+        except Exception as e:
+            raise HTTPException(status_code=400, detail=f"existing_experiences JSON 파싱 오류: {str(e)}")
+
     try:
         if file and file.filename:
             file_content = await file.read()
             if file.filename.lower().endswith(".pdf"):
-                return extract_step2_from_pdf(file_content, exp_list)
-            return extract_step2_from_text(file_content.decode("utf-8"), exp_list)
+                result = extract_step2_from_pdf(file_content, exp_list)
+            else:
+                result = extract_step2_from_text(file_content.decode("utf-8"), exp_list)
         elif url and url.strip():
-            return extract_step2_from_url(url.strip(), exp_list)
+            result = extract_step2_from_url(url.strip(), exp_list)
         else:
-            return extract_step2_from_text(text.strip(), exp_list)
+            result = extract_step2_from_text(text.strip(), exp_list)
+
+        result.experiences = apply_merge_results_to_step2(result.experiences, existing_exp_list)
+        return result
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.post("/experiences/merge-check", response_model=MergeCheckResponse)
+async def check_experience_merge(request: MergeCheckRequest):
+    """
+    새 경험 후보와 사용자의 기존 경험 목록을 임베딩 유사도로 비교하여 병합 후보를 반환합니다.
+    """
+    try:
+        return check_merge_candidates(
+            targets=request.targets,
+            existing_experiences=request.existing_experiences,
+            threshold=request.threshold,
+            top_k=request.top_k,
+        )
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 

--- a/myeongsung/app/schemas/resume_dto.py
+++ b/myeongsung/app/schemas/resume_dto.py
@@ -1,5 +1,5 @@
 from pydantic import BaseModel, Field
-from typing import List, Optional, Union, Any
+from typing import List, Optional, Union, Any, Dict
 from datetime import datetime
 
 # ── STAR 경험 입력 스키마 ──────────────────────────────────────
@@ -176,7 +176,50 @@ class Step2ExtractedExperience(BaseModel):
     ai_sentence_cards: List[str] = Field(default=[], description="AI 문장 카드")
     
     merge_candidate_id: Optional[str] = Field(default=None, description="병합 후보 ID")
+    merge_similarity: Optional[float] = Field(default=None, description="병합 후보와의 임베딩 유사도")
     writing_status: str = Field(default="in_progress", description="작성 종료 여부")
 
 class Step2ExtractionResponse(BaseModel):
     experiences: List[Step2ExtractedExperience] = Field(..., description="2차 추출된 경험 상세 목록")
+
+
+# ── 경험 병합 후보 검사 스키마 ──────────────────────────────────────
+class MergeExperiencePayload(BaseModel):
+    id: Optional[str] = Field(default=None, description="저장된 경험 ID. 신규 후보는 비워둘 수 있음")
+    title: Optional[str] = Field(default=None, description="경험 제목")
+    experience_name: Optional[str] = Field(default=None, description="경험명")
+    experience_group: Optional[str] = Field(default=None, description="경험 대분류")
+    experience_type: Optional[str] = Field(default=None, description="경험 소분류")
+    keywords: List[str] = Field(default=[], description="경험 키워드")
+    attributes: Dict[str, Any] = Field(default={}, description="저장 경험의 속성 JSON")
+    basic_info: Dict[str, Any] = Field(default={}, description="추출 경험의 유형별 기본 정보")
+    document_content: Optional[str] = Field(default=None, description="저장 경험 본문")
+    experience_content: Optional[str] = Field(default=None, description="추출 경험 본문")
+
+
+class MergeCheckRequest(BaseModel):
+    targets: List[MergeExperiencePayload] = Field(..., description="새로 저장하려는 경험 후보")
+    existing_experiences: List[MergeExperiencePayload] = Field(default=[], description="현재 사용자의 저장된 경험 전체")
+    threshold: Optional[float] = Field(default=None, description="병합 필요 판정 임계값")
+    top_k: int = Field(default=1, ge=1, description="target별 반환 후보 수. v1은 1 사용")
+
+
+class MergeCandidate(BaseModel):
+    id: Optional[str] = Field(default=None, description="병합 후보 경험 ID")
+    title: Optional[str] = Field(default=None, description="병합 후보 제목")
+    experience_group: Optional[str] = Field(default=None, description="병합 후보 대분류")
+    experience_type: Optional[str] = Field(default=None, description="병합 후보 소분류")
+    similarity: float = Field(..., description="target과 후보의 코사인 유사도")
+
+
+class MergeCheckResult(BaseModel):
+    target_index: int = Field(..., description="요청 targets 배열 내 index")
+    target_id: Optional[str] = Field(default=None, description="target ID")
+    needs_merge: bool = Field(..., description="병합 필요 여부")
+    merge_candidate_id: Optional[str] = Field(default=None, description="가장 유사한 병합 후보 ID")
+    similarity: Optional[float] = Field(default=None, description="가장 유사한 후보와의 유사도")
+    candidate: Optional[MergeCandidate] = Field(default=None, description="가장 유사한 후보 정보")
+
+
+class MergeCheckResponse(BaseModel):
+    results: List[MergeCheckResult] = Field(..., description="target별 병합 검사 결과")

--- a/myeongsung/app/services/experience_merge_service.py
+++ b/myeongsung/app/services/experience_merge_service.py
@@ -1,0 +1,292 @@
+import json
+import math
+import os
+from typing import Any, Iterable, List, Optional, Sequence
+from pydantic import BaseModel
+
+from app.schemas.resume_dto import (
+    MergeCandidate,
+    MergeCheckResponse,
+    MergeCheckResult,
+    MergeExperiencePayload,
+    Step2ExtractedExperience,
+)
+
+
+DEFAULT_MERGE_THRESHOLD = 0.86
+SPEC_TYPES = {"어학", "자격증", "수상", "수강과목", "교육 이수", "LANGUAGE", "LICENSE", "AWARD", "COURSE", "EDUCATION"}
+SPEC_FIELD_KEYS = {
+    "어학": ("exam_name", "score", "exam_date", "expiration_date"),
+    "LANGUAGE": ("exam_name", "score", "exam_date", "expiration_date"),
+    "자격증": ("certificate_name", "organization", "acquisition_date", "expiration_date"),
+    "LICENSE": ("certificate_name", "organization", "acquisition_date", "expiration_date"),
+    "수상": ("award_name", "organization", "award_date", "award_grade"),
+    "AWARD": ("award_name", "organization", "award_date", "award_grade"),
+    "수강과목": ("course_name", "semester", "credit", "grade", "major"),
+    "COURSE": ("course_name", "semester", "credit", "grade", "major"),
+    "교육 이수": ("education_name", "organization", "period", "completion_status"),
+    "EDUCATION": ("education_name", "organization", "period", "completion_status"),
+}
+
+
+def _merge_threshold(threshold: Optional[float] = None) -> float:
+    if threshold is not None:
+        return threshold
+    raw_value = os.getenv("MERGE_SIMILARITY_THRESHOLD")
+    if not raw_value:
+        return DEFAULT_MERGE_THRESHOLD
+    try:
+        return float(raw_value)
+    except ValueError:
+        return DEFAULT_MERGE_THRESHOLD
+
+
+def _embedding_model() -> str:
+    return os.getenv("EMBEDDING_MODEL", "text-embedding-3-small")
+
+
+def _as_dict(value: Any) -> dict:
+    if isinstance(value, BaseModel):
+        return value.model_dump()
+    if isinstance(value, dict):
+        return value
+    return {}
+
+
+def _compact_json(value: Any) -> str:
+    if value is None or value == {} or value == []:
+        return ""
+    return json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+
+
+def _first_present(data: dict, keys: Iterable[str]) -> str:
+    for key in keys:
+        value = data.get(key)
+        if value is not None and str(value).strip():
+            return str(value).strip()
+    return ""
+
+
+def _experience_type(data: dict) -> str:
+    return _first_present(data, ("experience_type", "experienceType"))
+
+
+def _experience_group(data: dict) -> str:
+    return _first_present(data, ("experience_group", "experienceGroup"))
+
+
+def _is_spec_experience(data: dict) -> bool:
+    group = _experience_group(data).replace(" ", "")
+    experience_type = _experience_type(data)
+    return group in {"스펙·증빙형", "스펙증빙형", "SPEC"} or experience_type in SPEC_TYPES
+
+
+def _structured_info(data: dict) -> dict:
+    info = {}
+    attributes = data.get("attributes")
+    if isinstance(attributes, dict):
+        info.update(attributes)
+    basic_info = data.get("basic_info") or data.get("basicInfo")
+    if isinstance(basic_info, dict):
+        info.update(basic_info)
+    return info
+
+
+def _structured_parts(info: dict, keys: Iterable[str]) -> List[str]:
+    parts = []
+    for key in keys:
+        value = info.get(key)
+        if value is not None and str(value).strip():
+            parts.append(f"{key}: {str(value).strip()}")
+    return parts
+
+
+def _spec_embedding_text(data: dict) -> str:
+    title = _first_present(data, ("title", "experience_name"))
+    experience_type = _experience_type(data)
+    info = _structured_info(data)
+    field_keys = SPEC_FIELD_KEYS.get(experience_type, ())
+    structured_parts = _structured_parts(info, field_keys)
+    fallback_body = _first_present(data, ("document_content", "experience_content", "documentContent", "experienceContent"))
+
+    identity = [
+        title,
+        experience_type,
+        *structured_parts,
+    ]
+    if not structured_parts and fallback_body:
+        identity.append(fallback_body)
+
+    weighted_identity = [part for part in identity if part]
+    primary_identity = weighted_identity[:2]
+    return "\n".join([*primary_identity, *weighted_identity])
+
+
+def _narrative_embedding_text(data: dict) -> str:
+    title = _first_present(data, ("title", "experience_name"))
+    body = _first_present(data, ("document_content", "experience_content", "documentContent", "experienceContent"))
+    keywords = data.get("keywords") or []
+    if not isinstance(keywords, list):
+        keywords = [str(keywords)]
+
+    parts = [
+        title,
+        _experience_group(data),
+        _experience_type(data),
+        " ".join(str(keyword) for keyword in keywords if str(keyword).strip()),
+        _compact_json(_structured_info(data)),
+        body,
+    ]
+    return "\n".join(part for part in parts if part)
+
+
+def build_embedding_text(experience: Any) -> str:
+    data = _as_dict(experience)
+    if _is_spec_experience(data):
+        return _spec_embedding_text(data)
+    return _narrative_embedding_text(data)
+
+
+def _embedding_client() -> Any:
+    from openai import OpenAI
+
+    return OpenAI(api_key=os.getenv("OPENAI_API_KEY") or None)
+
+
+def _embed_texts(texts: Sequence[str], client: Optional[Any] = None) -> List[List[float]]:
+    if not texts:
+        return []
+    openai_client = client or _embedding_client()
+    response = openai_client.embeddings.create(model=_embedding_model(), input=list(texts))
+    return [item.embedding for item in response.data]
+
+
+def _cosine_similarity(left: Sequence[float], right: Sequence[float]) -> float:
+    dot = sum(a * b for a, b in zip(left, right))
+    left_norm = math.sqrt(sum(a * a for a in left))
+    right_norm = math.sqrt(sum(b * b for b in right))
+    if left_norm == 0 or right_norm == 0:
+        return 0.0
+    return dot / (left_norm * right_norm)
+
+
+def _payload_title(experience: Any) -> Optional[str]:
+    data = _as_dict(experience)
+    return _first_present(data, ("title", "experience_name")) or None
+
+
+def _payload_id(experience: Any) -> Optional[str]:
+    data = _as_dict(experience)
+    value = data.get("id")
+    return str(value) if value is not None else None
+
+
+def _candidate_from_payload(experience: Any, similarity: float) -> MergeCandidate:
+    data = _as_dict(experience)
+    return MergeCandidate(
+        id=_payload_id(data),
+        title=_payload_title(data),
+        experience_group=_first_present(data, ("experience_group", "experienceGroup")) or None,
+        experience_type=_first_present(data, ("experience_type", "experienceType")) or None,
+        similarity=similarity,
+    )
+
+
+def _is_comparable(target: Any, candidate: Any) -> bool:
+    target_data = _as_dict(target)
+    candidate_data = _as_dict(candidate)
+    target_is_spec = _is_spec_experience(target_data)
+    candidate_is_spec = _is_spec_experience(candidate_data)
+
+    if target_is_spec != candidate_is_spec:
+        return False
+    if target_is_spec and candidate_is_spec:
+        target_type = _experience_type(target_data)
+        candidate_type = _experience_type(candidate_data)
+        return not target_type or not candidate_type or target_type == candidate_type
+    return True
+
+
+def _empty_result(target: Any, index: int) -> MergeCheckResult:
+    return MergeCheckResult(
+        target_index=index,
+        target_id=_payload_id(target),
+        needs_merge=False,
+        merge_candidate_id=None,
+        similarity=None,
+        candidate=None,
+    )
+
+
+def check_merge_candidates(
+    targets: List[Any],
+    existing_experiences: List[Any],
+    threshold: Optional[float] = None,
+    top_k: int = 1,
+    embedding_client: Optional[Any] = None,
+) -> MergeCheckResponse:
+    effective_threshold = _merge_threshold(threshold)
+
+    if not targets:
+        return MergeCheckResponse(results=[])
+    if not existing_experiences:
+        return MergeCheckResponse(results=[_empty_result(target, index) for index, target in enumerate(targets)])
+
+    target_texts = [build_embedding_text(target) for target in targets]
+    existing_texts = [build_embedding_text(experience) for experience in existing_experiences]
+    embeddings = _embed_texts([*target_texts, *existing_texts], client=embedding_client)
+    target_embeddings = embeddings[: len(targets)]
+    existing_embeddings = embeddings[len(targets):]
+
+    results: List[MergeCheckResult] = []
+    for target_index, target_embedding in enumerate(target_embeddings):
+        scored_candidates = [
+            (_cosine_similarity(target_embedding, existing_embedding), existing_experiences[existing_index])
+            for existing_index, existing_embedding in enumerate(existing_embeddings)
+            if _is_comparable(targets[target_index], existing_experiences[existing_index])
+        ]
+        if not scored_candidates:
+            results.append(_empty_result(targets[target_index], target_index))
+            continue
+        scored_candidates.sort(key=lambda item: item[0], reverse=True)
+        best_similarity, best_candidate = scored_candidates[0]
+        needs_merge = best_similarity >= effective_threshold
+        candidate = _candidate_from_payload(best_candidate, best_similarity) if needs_merge else None
+        results.append(
+            MergeCheckResult(
+                target_index=target_index,
+                target_id=_payload_id(targets[target_index]),
+                needs_merge=needs_merge,
+                merge_candidate_id=candidate.id if candidate else None,
+                similarity=best_similarity,
+                candidate=candidate,
+            )
+        )
+
+    return MergeCheckResponse(results=results)
+
+
+def apply_merge_results_to_step2(
+    step2_experiences: List[Step2ExtractedExperience],
+    existing_experiences: List[MergeExperiencePayload],
+    threshold: Optional[float] = None,
+) -> List[Step2ExtractedExperience]:
+    if not step2_experiences or not existing_experiences:
+        return step2_experiences
+
+    merge_response = check_merge_candidates(
+        targets=step2_experiences,
+        existing_experiences=existing_experiences,
+        threshold=threshold,
+        top_k=1,
+    )
+    results_by_index = {result.target_index: result for result in merge_response.results}
+    for index, experience in enumerate(step2_experiences):
+        result = results_by_index.get(index)
+        if not result:
+            continue
+        experience.needs_merge = result.needs_merge
+        experience.merge_candidate_id = result.merge_candidate_id
+        experience.merge_similarity = result.similarity
+
+    return step2_experiences

--- a/myeongsung/app/services/experience_merge_service.py
+++ b/myeongsung/app/services/experience_merge_service.py
@@ -1,6 +1,8 @@
 import json
 import math
 import os
+import re
+from difflib import SequenceMatcher
 from typing import Any, Iterable, List, Optional, Sequence
 from pydantic import BaseModel
 
@@ -14,6 +16,10 @@ from app.schemas.resume_dto import (
 
 
 DEFAULT_MERGE_THRESHOLD = 0.86
+LOW_CONFIDENCE_MERGE_THRESHOLD = 0.75
+NAME_SIMILARITY_THRESHOLD = 0.9
+KEY_FIELD_MATCH_THRESHOLD = 2
+URL_PATTERN = re.compile(r"https?://[^\s\])}>\"']+")
 SPEC_TYPES = {"어학", "자격증", "수상", "수강과목", "교육 이수", "LANGUAGE", "LICENSE", "AWARD", "COURSE", "EDUCATION"}
 SPEC_FIELD_KEYS = {
     "어학": ("exam_name", "score", "exam_date", "expiration_date"),
@@ -27,6 +33,14 @@ SPEC_FIELD_KEYS = {
     "교육 이수": ("education_name", "organization", "period", "completion_status"),
     "EDUCATION": ("education_name", "organization", "period", "completion_status"),
 }
+NARRATIVE_KEY_FIELDS = (
+    "project_name",
+    "activity_name",
+    "competition_name",
+    "organization",
+    "period",
+    "role",
+)
 
 
 def _merge_threshold(threshold: Optional[float] = None) -> float:
@@ -57,6 +71,20 @@ def _compact_json(value: Any) -> str:
     if value is None or value == {} or value == []:
         return ""
     return json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+
+
+def _normalize_text(value: Any) -> str:
+    if value is None:
+        return ""
+    return re.sub(r"[\s_\-·./()]+", "", str(value).casefold())
+
+
+def _text_similarity(left: Any, right: Any) -> float:
+    left_value = _normalize_text(left)
+    right_value = _normalize_text(right)
+    if not left_value or not right_value:
+        return 0.0
+    return SequenceMatcher(None, left_value, right_value).ratio()
 
 
 def _first_present(data: dict, keys: Iterable[str]) -> str:
@@ -90,6 +118,37 @@ def _structured_info(data: dict) -> dict:
     if isinstance(basic_info, dict):
         info.update(basic_info)
     return info
+
+
+def _all_text_values(value: Any) -> List[str]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        return [value]
+    if isinstance(value, dict):
+        values = []
+        for child in value.values():
+            values.extend(_all_text_values(child))
+        return values
+    if isinstance(value, list):
+        values = []
+        for child in value:
+            values.extend(_all_text_values(child))
+        return values
+    return [str(value)]
+
+
+def _extract_urls(data: dict) -> set[str]:
+    values = [
+        _first_present(data, ("document_content", "experience_content", "documentContent", "experienceContent")),
+        *_all_text_values(_structured_info(data)),
+        *_all_text_values(data.get("related_links")),
+        *_all_text_values(data.get("links")),
+    ]
+    urls = set()
+    for value in values:
+        urls.update(URL_PATTERN.findall(value))
+    return {url.rstrip(".,") for url in urls}
 
 
 def _structured_parts(info: dict, keys: Iterable[str]) -> List[str]:
@@ -192,6 +251,58 @@ def _candidate_from_payload(experience: Any, similarity: float) -> MergeCandidat
     )
 
 
+def _title_similarity(target_data: dict, candidate_data: dict) -> float:
+    return _text_similarity(_payload_title(target_data), _payload_title(candidate_data))
+
+
+def _same_url_exists(target_data: dict, candidate_data: dict) -> bool:
+    target_urls = _extract_urls(target_data)
+    candidate_urls = _extract_urls(candidate_data)
+    return bool(target_urls and candidate_urls and target_urls.intersection(candidate_urls))
+
+
+def _field_matches(target_data: dict, candidate_data: dict, fields: Iterable[str]) -> int:
+    target_info = _structured_info(target_data)
+    candidate_info = _structured_info(candidate_data)
+    matches = 0
+    for field in fields:
+        target_value = target_info.get(field)
+        candidate_value = candidate_info.get(field)
+        if target_value is None or candidate_value is None:
+            continue
+        if _text_similarity(target_value, candidate_value) >= 0.85:
+            matches += 1
+    return matches
+
+
+def _spec_field_matches(target_data: dict, candidate_data: dict) -> int:
+    experience_type = _experience_type(target_data) or _experience_type(candidate_data)
+    return _field_matches(target_data, candidate_data, SPEC_FIELD_KEYS.get(experience_type, ()))
+
+
+def _narrative_field_matches(target_data: dict, candidate_data: dict) -> int:
+    return _field_matches(target_data, candidate_data, NARRATIVE_KEY_FIELDS)
+
+
+def _rule_based_merge(target: Any, candidate: Any, similarity: float, threshold: float) -> bool:
+    target_data = _as_dict(target)
+    candidate_data = _as_dict(candidate)
+
+    if similarity >= threshold:
+        return True
+    if _same_url_exists(target_data, candidate_data):
+        return True
+
+    title_similarity = _title_similarity(target_data, candidate_data)
+    if _is_spec_experience(target_data):
+        return title_similarity >= NAME_SIMILARITY_THRESHOLD and _spec_field_matches(target_data, candidate_data) >= 1
+
+    narrative_matches = _narrative_field_matches(target_data, candidate_data)
+    if title_similarity >= NAME_SIMILARITY_THRESHOLD and narrative_matches >= 1:
+        return True
+    return similarity >= LOW_CONFIDENCE_MERGE_THRESHOLD and narrative_matches >= KEY_FIELD_MATCH_THRESHOLD
+
+
 def _is_comparable(target: Any, candidate: Any) -> bool:
     target_data = _as_dict(target)
     candidate_data = _as_dict(candidate)
@@ -250,7 +361,12 @@ def check_merge_candidates(
             continue
         scored_candidates.sort(key=lambda item: item[0], reverse=True)
         best_similarity, best_candidate = scored_candidates[0]
-        needs_merge = best_similarity >= effective_threshold
+        needs_merge = _rule_based_merge(
+            targets[target_index],
+            best_candidate,
+            best_similarity,
+            effective_threshold,
+        )
         candidate = _candidate_from_payload(best_candidate, best_similarity) if needs_merge else None
         results.append(
             MergeCheckResult(

--- a/myeongsung/tests/test_experience_merge_service.py
+++ b/myeongsung/tests/test_experience_merge_service.py
@@ -1,0 +1,116 @@
+from types import SimpleNamespace
+import unittest
+
+from app.schemas.resume_dto import MergeExperiencePayload, Step2ExtractedExperience
+from app.services.experience_merge_service import build_embedding_text, check_merge_candidates
+
+
+class FakeEmbeddings:
+    def create(self, model, input):
+        vectors = []
+        for text in input:
+            if "캡스톤 AI 프로젝트" in text or "AI 프로젝트 개선" in text:
+                vectors.append([1.0, 0.0])
+            else:
+                vectors.append([0.0, 1.0])
+        return SimpleNamespace(data=[SimpleNamespace(embedding=vector) for vector in vectors])
+
+
+class FakeOpenAI:
+    embeddings = FakeEmbeddings()
+
+
+class ExperienceMergeServiceTest(unittest.TestCase):
+
+    def test_check_merge_candidates_marks_similar_target(self):
+        targets = [
+            MergeExperiencePayload(
+                title="AI 프로젝트 개선",
+                experience_group="상세 서술형",
+                experience_type="프로젝트",
+                document_content="추천 모델을 개선했습니다.",
+            ),
+            MergeExperiencePayload(
+                title="토익 900점",
+                experience_group="스펙·증빙형",
+                experience_type="어학",
+                document_content="토익 점수를 취득했습니다.",
+            ),
+        ]
+        existing = [
+            MergeExperiencePayload(
+                id="exp-1",
+                title="캡스톤 AI 프로젝트",
+                experience_group="상세 서술형",
+                experience_type="프로젝트",
+                document_content="AI 추천 모델 프로젝트입니다.",
+            )
+        ]
+
+        response = check_merge_candidates(targets, existing, threshold=0.86, embedding_client=FakeOpenAI())
+
+        self.assertTrue(response.results[0].needs_merge)
+        self.assertEqual("exp-1", response.results[0].merge_candidate_id)
+        self.assertEqual(1.0, response.results[0].similarity)
+        self.assertFalse(response.results[1].needs_merge)
+        self.assertIsNone(response.results[1].merge_candidate_id)
+
+    def test_build_embedding_text_supports_step2_shape(self):
+        experience = Step2ExtractedExperience(
+            experience_name="공모전 수상",
+            experience_group="상세 서술형",
+            experience_type="공모전",
+            keywords=["기획력"],
+            basic_info={"organization": "테스트 기관"},
+            experience_content="공모전에서 서비스를 기획했습니다.",
+        )
+
+        text = build_embedding_text(experience)
+
+        self.assertIn("공모전 수상", text)
+        self.assertIn("기획력", text)
+        self.assertIn("테스트 기관", text)
+        self.assertIn("공모전에서 서비스를 기획했습니다.", text)
+
+    def test_spec_embedding_text_prefers_structured_fields(self):
+        experience = MergeExperiencePayload(
+            title="토익 900점",
+            experience_group="스펙·증빙형",
+            experience_type="어학",
+            basic_info={
+                "exam_name": "TOEIC",
+                "score": "900",
+                "exam_date": "2025-03-01",
+            },
+            document_content="여러 스펙이 함께 적힌 긴 본문입니다.",
+        )
+
+        text = build_embedding_text(experience)
+
+        self.assertIn("TOEIC", text)
+        self.assertIn("score: 900", text)
+        self.assertNotIn("여러 스펙이 함께 적힌 긴 본문입니다.", text)
+
+    def test_spec_experiences_with_different_types_are_not_compared(self):
+        target = MergeExperiencePayload(
+            title="토익 900점",
+            experience_group="스펙·증빙형",
+            experience_type="어학",
+            basic_info={"exam_name": "TOEIC", "score": "900"},
+        )
+        existing = MergeExperiencePayload(
+            id="license-1",
+            title="정보처리기사",
+            experience_group="스펙·증빙형",
+            experience_type="자격증",
+            basic_info={"certificate_name": "정보처리기사"},
+        )
+
+        response = check_merge_candidates([target], [existing], threshold=0.86, embedding_client=FakeOpenAI())
+
+        self.assertFalse(response.results[0].needs_merge)
+        self.assertIsNone(response.results[0].similarity)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/myeongsung/tests/test_experience_merge_service.py
+++ b/myeongsung/tests/test_experience_merge_service.py
@@ -20,6 +20,20 @@ class FakeOpenAI:
     embeddings = FakeEmbeddings()
 
 
+class LowSimilarityEmbeddings:
+    def create(self, model, input):
+        return SimpleNamespace(
+            data=[
+                SimpleNamespace(embedding=[1.0, 0.0]),
+                SimpleNamespace(embedding=[0.76, 0.649923]),
+            ]
+        )
+
+
+class LowSimilarityOpenAI:
+    embeddings = LowSimilarityEmbeddings()
+
+
 class ExperienceMergeServiceTest(unittest.TestCase):
 
     def test_check_merge_candidates_marks_similar_target(self):
@@ -110,6 +124,66 @@ class ExperienceMergeServiceTest(unittest.TestCase):
 
         self.assertFalse(response.results[0].needs_merge)
         self.assertIsNone(response.results[0].similarity)
+
+    def test_same_url_marks_merge_even_with_short_content(self):
+        target = MergeExperiencePayload(
+            title="FIn-agent",
+            experience_group="상세 서술형",
+            experience_type="프로젝트",
+            experience_content="https://github.com/tomchaccom/Fin_AI_Agent",
+        )
+        existing = MergeExperiencePayload(
+            id="exp-1",
+            title="Fin-agent",
+            experience_group="상세 서술형",
+            experience_type="공모전",
+            experience_content="프로젝트 링크: https://github.com/tomchaccom/Fin_AI_Agent",
+        )
+
+        response = check_merge_candidates([target], [existing], threshold=0.86, embedding_client=LowSimilarityOpenAI())
+
+        self.assertTrue(response.results[0].needs_merge)
+        self.assertEqual("exp-1", response.results[0].merge_candidate_id)
+
+    def test_similar_name_and_organization_marks_merge(self):
+        target = MergeExperiencePayload(
+            title="FIn-agent",
+            experience_group="상세 서술형",
+            experience_type="프로젝트",
+            basic_info={"organization": "미래에셋"},
+        )
+        existing = MergeExperiencePayload(
+            id="exp-1",
+            title="Fin agent",
+            experience_group="상세 서술형",
+            experience_type="공모전",
+            basic_info={"organization": "미래에셋"},
+        )
+
+        response = check_merge_candidates([target], [existing], threshold=0.86, embedding_client=LowSimilarityOpenAI())
+
+        self.assertTrue(response.results[0].needs_merge)
+        self.assertEqual("exp-1", response.results[0].merge_candidate_id)
+
+    def test_low_embedding_with_two_key_field_matches_marks_merge(self):
+        target = MergeExperiencePayload(
+            title="금융 AI Agent",
+            experience_group="상세 서술형",
+            experience_type="프로젝트",
+            basic_info={"organization": "미래에셋", "period": "2025.06.28 ~ 07.31"},
+        )
+        existing = MergeExperiencePayload(
+            id="exp-1",
+            title="Fin-agent",
+            experience_group="상세 서술형",
+            experience_type="공모전",
+            basic_info={"organization": "미래에셋", "period": "2025.06.28~07.31"},
+        )
+
+        response = check_merge_candidates([target], [existing], threshold=0.86, embedding_client=LowSimilarityOpenAI())
+
+        self.assertTrue(response.results[0].needs_merge)
+        self.assertEqual("exp-1", response.results[0].merge_candidate_id)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# 작업 내용 
-  동일 URL 기반 병합 후보 판정 추가
- 경험명과 핵심 필드 매칭 기반 보정 추가
- 짧은 경험 병합 판정 테스트 추가