### PR TITLE
fix: AI↔BE 계약 통일 및 async 성능 최적화 (closes #35)

### DIFF
--- a/myeongsung/AGENTS.md
+++ b/myeongsung/AGENTS.md
@@ -24,6 +24,52 @@ Follow it before editing code.
 - `tests/`: unit tests for service behavior.
 - `test_api.sh`: manual API smoke checks that may call external APIs.
 
+## Code Change Confirmation Rule
+
+**Before editing any code, always show the problem at code level and get explicit confirmation.**
+
+1. Identify the exact file, function, and line range that has the problem.
+2. Show the current problematic code as a code block.
+3. Explain why it is a problem (performance, correctness, maintainability).
+4. Wait for the user to confirm before making any edits.
+
+Do not skip this step even for small or "obvious" fixes.
+
+## Git and PR Conventions
+
+### Branch naming
+- Basic: `AI/feat/{issue_number}-{description}`
+- Stack PR: `AI/{type}/{issue_number}-{stack_num}/{stack_total}-{description}`
+- Types: `feat`, `fix`, `refactor`, `test`
+
+### Issue title
+`[feat|fix|refactor|test] : {description}`
+Example: `[refactor] : 임베딩 N회 발생 최적화`
+
+### PR title
+`[{issue_number} - Stack {n}/{total}] {description}`
+Example: `[32 - Stack 1/1] 임베딩 N회 발생 최적화`
+
+### PR body template
+```
+## 관련 이슈
+- #{issue_number}
+- Stack PR: {n}/{total}
+- Base: `{base_branch}`
+## 문제
+{problem_description}
+## 작업 내용
+- task 1
+- task 2
+## 테스트
+- test case 1
+- test case 2
+```
+
+### Automation script
+Use `pick/create_pr.sh` for issue creation, branch setup, commit, push, and PR creation.
+See comments at the top of the script for usage.
+
 ## First Step For Every Feature Request
 
 Before implementing, identify and report the likely change scope:

--- a/myeongsung/app/api/experience_extraction_v2.py
+++ b/myeongsung/app/api/experience_extraction_v2.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 from typing import List, Optional
 
@@ -85,31 +86,36 @@ async def extract_experiences_step2_v2(
         if file and file.filename:
             file_content = await file.read()
             if file.filename.lower().endswith(".pdf"):
-                result = extract_step2_v2_from_pdf(
+                result = await asyncio.to_thread(
+                    extract_step2_v2_from_pdf,
                     file_content,
                     selected_list,
                     preset_list,
                 )
             else:
-                result = extract_step2_v2_from_text(
+                result = await asyncio.to_thread(
+                    extract_step2_v2_from_text,
                     file_content.decode("utf-8"),
                     selected_list,
                     preset_list,
                 )
         elif url and url.strip():
-            result = extract_step2_v2_from_url(
+            result = await asyncio.to_thread(
+                extract_step2_v2_from_url,
                 url.strip(),
                 selected_list,
                 preset_list,
             )
         else:
-            result = extract_step2_v2_from_text(
+            result = await asyncio.to_thread(
+                extract_step2_v2_from_text,
                 text.strip(),
                 selected_list,
                 preset_list,
             )
 
-        result.experiences = apply_sequential_merge_results_to_step2(
+        result.experiences = await asyncio.to_thread(
+            apply_sequential_merge_results_to_step2,
             result.experiences,
             existing_list,
         )

--- a/myeongsung/app/api/router.py
+++ b/myeongsung/app/api/router.py
@@ -5,6 +5,7 @@ Resume Strategist API — 라우터 (Controller 레이어)
 비즈니스 로직은 services/ 하위 모듈에서 처리합니다.
 """
 
+import asyncio
 import json
 from typing import Optional, List
 
@@ -62,7 +63,7 @@ async def analyze_url(request: UrlAnalysisRequest, response: Response, backgroun
     분석 완료 후 백그라운드에서 정확도를 평가하고, 응답 헤더에 신뢰도 점수를 포함합니다.
     """
     try:
-        result = analyze_job_url(request.url)
+        result = await asyncio.to_thread(analyze_job_url, request.url)
 
         # 신뢰도 점수 계산 후 헤더에 포함 (Spring 서버에서 확인 가능)
         confidence_score = sum([
@@ -89,7 +90,7 @@ async def analyze_pdf(file: UploadFile = File(...)):
     """
     try:
         file_content = await file.read()
-        return analyze_job_pdf(file_content)
+        return await asyncio.to_thread(analyze_job_pdf, file_content)
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 
@@ -102,7 +103,7 @@ async def analyze_image(files: List[UploadFile] = File(...)):
     """
     try:
         image_contents = [await file.read() for file in files]
-        return analyze_job_image(image_contents)
+        return await asyncio.to_thread(analyze_job_image, image_contents)
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 
@@ -134,12 +135,12 @@ async def extract_experiences(
         if file and file.filename:
             file_content = await file.read()
             if file.filename.lower().endswith(".pdf"):
-                return extract_experiences_from_pdf(file_content)
-            return extract_experiences_from_text(file_content.decode("utf-8"))
+                return await asyncio.to_thread(extract_experiences_from_pdf, file_content)
+            return await asyncio.to_thread(extract_experiences_from_text, file_content.decode("utf-8"))
         elif url and url.strip():
-            return extract_experiences_from_url(url.strip())
+            return await asyncio.to_thread(extract_experiences_from_url, url.strip())
         else:
-            return extract_experiences_from_text(text.strip())
+            return await asyncio.to_thread(extract_experiences_from_text, text.strip())
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 
@@ -165,12 +166,12 @@ async def extract_experiences_step1(
         if file and file.filename:
             file_content = await file.read()
             if file.filename.lower().endswith(".pdf"):
-                return extract_step1_from_pdf(file_content)
-            return extract_step1_from_text(file_content.decode("utf-8"))
+                return await asyncio.to_thread(extract_step1_from_pdf, file_content)
+            return await asyncio.to_thread(extract_step1_from_text, file_content.decode("utf-8"))
         elif url and url.strip():
-            return extract_step1_from_url(url.strip())
+            return await asyncio.to_thread(extract_step1_from_url, url.strip())
         else:
-            return extract_step1_from_text(text.strip())
+            return await asyncio.to_thread(extract_step1_from_text, text.strip())
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 
@@ -215,15 +216,15 @@ async def extract_experiences_step2(
         if file and file.filename:
             file_content = await file.read()
             if file.filename.lower().endswith(".pdf"):
-                result = extract_step2_from_pdf(file_content, exp_list)
+                result = await asyncio.to_thread(extract_step2_from_pdf, file_content, exp_list)
             else:
-                result = extract_step2_from_text(file_content.decode("utf-8"), exp_list)
+                result = await asyncio.to_thread(extract_step2_from_text, file_content.decode("utf-8"), exp_list)
         elif url and url.strip():
-            result = extract_step2_from_url(url.strip(), exp_list)
+            result = await asyncio.to_thread(extract_step2_from_url, url.strip(), exp_list)
         else:
-            result = extract_step2_from_text(text.strip(), exp_list)
+            result = await asyncio.to_thread(extract_step2_from_text, text.strip(), exp_list)
 
-        result.experiences = apply_merge_results_to_step2(result.experiences, existing_exp_list)
+        result.experiences = await asyncio.to_thread(apply_merge_results_to_step2, result.experiences, existing_exp_list)
         return result
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
@@ -235,11 +236,12 @@ async def check_experience_merge(request: MergeCheckRequest):
     새 경험 후보와 사용자의 기존 경험 목록을 임베딩 유사도로 비교하여 병합 후보를 반환합니다.
     """
     try:
-        return check_merge_candidates(
-            targets=request.targets,
-            existing_experiences=request.existing_experiences,
-            threshold=request.threshold,
-            top_k=request.top_k,
+        return await asyncio.to_thread(
+            check_merge_candidates,
+            request.targets,
+            request.existing_experiences,
+            request.threshold,
+            request.top_k,
         )
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
@@ -267,7 +269,7 @@ async def analyze_and_place(
 
     # 1. 입력 파싱 및 검증 (서비스 레이어에 위임)
     try:
-        validated_experiences = parse_and_validate_experiences(experiences_json)
+        validated_experiences = await asyncio.to_thread(parse_and_validate_experiences, experiences_json)
         raw_prompts = json.loads(essay_prompts_json)
         if not isinstance(raw_prompts, list):
             raise ValueError("essay_prompts_json 필드는 문자열 배열 형태여야 합니다.")
@@ -300,7 +302,7 @@ async def analyze_and_place(
 
     # 4. LangGraph 워크플로우 실행
     try:
-        final_state = workflow.invoke(initial_state)
+        final_state = await asyncio.to_thread(workflow.invoke, initial_state)
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"내부 파이프라인 실행 중 오류 발생: {str(e)}")
 

--- a/myeongsung/app/schemas/job_dto.py
+++ b/myeongsung/app/schemas/job_dto.py
@@ -87,7 +87,7 @@ class JobPostingBase(BaseModel):
     started_at: str = Field(..., description="접수 시작일 (YYYY-MM-DDTHH:MM:SS)")
     ended_at: Optional[str] = Field(None, description="접수 마감일 (YYYY-MM-DDTHH:MM:SS)")
     notice_url: Optional[str] = Field(None, description="지원 링크")
-    headcount: Optional[int] = Field(0, description="채용 인원")
+    headcount: Optional[str] = Field(None, description="채용 인원 (예: '00명', '0명 이상')")
     region_1depth: Optional[str] = Field(None, description="근무지역")
     workplace_address: Optional[str] = Field(None, description="근무지")
 

--- a/myeongsung/app/services/experience_merge_service.py
+++ b/myeongsung/app/services/experience_merge_service.py
@@ -414,22 +414,54 @@ def apply_sequential_merge_results_to_step2(
     threshold: Optional[float] = None,
     embedding_client: Optional[Any] = None,
 ) -> List[dict]:
+    """새 경험들과 기존 경험들을 순차적으로 중복 판정한다.
+
+    기존 구현은 루프마다 check_merge_candidates → _embed_texts(OpenAI API)를 호출해
+    경험 N개 기준으로 API가 N번 발생했다. 이 구현은 시작 전에 전체 텍스트를 한 번만
+    임베딩하고, 이후 비교는 저장된 벡터(코사인 유사도 계산)만으로 수행한다.
+    """
+    if not step2_experiences:
+        return step2_experiences
+
+    effective_threshold = _merge_threshold(threshold)
+
+    # 1. 모든 텍스트를 한 번에 임베딩 (API 호출 1회)
+    all_items: List[Any] = [*step2_experiences, *existing_experiences]
+    all_texts = [build_embedding_text(item) for item in all_items]
+    all_embeddings = _embed_texts(all_texts, client=embedding_client)
+
+    target_embeddings = all_embeddings[: len(step2_experiences)]
+    existing_embeddings = all_embeddings[len(step2_experiences):]
+
+    # 2. sequential 비교 — 벡터 재사용, 추가 API 호출 없음
+    accepted_embeddings: List[List[float]] = list(existing_embeddings)
     accepted_candidates: List[Any] = list(existing_experiences)
 
     for index, experience in enumerate(step2_experiences):
-        merge_response = check_merge_candidates(
-            targets=[experience],
-            existing_experiences=accepted_candidates,
-            threshold=threshold,
-            top_k=1,
-            embedding_client=embedding_client,
-        )
-        result = merge_response.results[0]
-        experience["needs_merge"] = result.needs_merge
-        experience["merge_candidate_id"] = result.merge_candidate_id
-        experience["merge_similarity"] = result.similarity
+        target_vec = target_embeddings[index]
 
-        if not result.needs_merge:
+        scored = [
+            (_cosine_similarity(target_vec, accepted_embeddings[j]), accepted_candidates[j])
+            for j in range(len(accepted_candidates))
+            if _is_comparable(experience, accepted_candidates[j])
+        ]
+
+        if not scored:
+            experience["needs_merge"] = False
+            experience["merge_candidate_id"] = None
+            experience["merge_similarity"] = None
+        else:
+            scored.sort(key=lambda x: x[0], reverse=True)
+            best_similarity, best_candidate = scored[0]
+            needs_merge = _rule_based_merge(
+                experience, best_candidate, best_similarity, effective_threshold
+            )
+            experience["needs_merge"] = needs_merge
+            experience["merge_candidate_id"] = _payload_id(best_candidate) if needs_merge else None
+            experience["merge_similarity"] = best_similarity
+
+        if not experience["needs_merge"]:
+            accepted_embeddings.append(target_vec)
             accepted_candidate = dict(experience)
             accepted_candidate["id"] = f"batch:{index}"
             accepted_candidates.append(accepted_candidate)

--- a/myeongsung/pytest.ini
+++ b/myeongsung/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+pythonpath = .

--- a/myeongsung/tests/test_schemas.py
+++ b/myeongsung/tests/test_schemas.py
@@ -1,0 +1,277 @@
+"""
+tests/test_schemas.py
+
+Pydantic 스키마 파싱 단위 테스트.
+외부 API 호출 없이 스키마 검증만 수행합니다.
+"""
+
+import pytest
+from pydantic import ValidationError
+
+from app.schemas.job_dto import JobPostingBase, NoticeSectionDTO
+from app.schemas.resume_dto import (
+    ExperienceSummary,
+    Step2ExtractedExperience,
+    ProjectInfo,
+)
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# 작업 1: JobPostingBase.headcount 타입 검증
+# ──────────────────────────────────────────────────────────────────────────────
+
+def _base_job_posting_dict(**overrides):
+    """JobPostingBase 필수 필드 포함 기본 dict."""
+    data = {
+        "company_name": "테스트기업",
+        "notice_name": "2024 하반기 공채",
+        "category": "FULL_TIME",
+        "started_at": "2024-09-01T00:00:00",
+    }
+    data.update(overrides)
+    return data
+
+
+class TestHeadcountType:
+    def test_headcount_string_00명_내외(self):
+        data = _base_job_posting_dict(headcount="00명 내외")
+        job = JobPostingBase(**data)
+        assert job.headcount == "00명 내외"
+
+    def test_headcount_string_5명(self):
+        data = _base_job_posting_dict(headcount="5명")
+        job = JobPostingBase(**data)
+        assert job.headcount == "5명"
+
+    def test_headcount_none(self):
+        data = _base_job_posting_dict(headcount=None)
+        job = JobPostingBase(**data)
+        assert job.headcount is None
+
+    def test_headcount_default_is_none(self):
+        data = _base_job_posting_dict()
+        job = JobPostingBase(**data)
+        assert job.headcount is None
+
+    def test_headcount_int_raises_validation_error(self):
+        """Pydantic v2는 str 필드에 int를 넣으면 ValidationError를 발생시킨다 (묵시적 coercion 없음)."""
+        data = _base_job_posting_dict(headcount=5)
+        with pytest.raises(ValidationError):
+            JobPostingBase(**data)
+
+    def test_headcount_string_0명_이상(self):
+        data = _base_job_posting_dict(headcount="0명 이상")
+        job = JobPostingBase(**data)
+        assert job.headcount == "0명 이상"
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# 작업 2: ExperienceSummary 파싱
+# ──────────────────────────────────────────────────────────────────────────────
+
+class TestExperienceSummary:
+    def test_experience_group_상세_서술형(self):
+        exp = ExperienceSummary(
+            experience_name="캡스톤 디자인 프로젝트",
+            experience_group="상세 서술형",
+            experience_type="프로젝트",
+        )
+        assert exp.experience_group == "상세 서술형"
+
+    def test_experience_group_스펙증빙형(self):
+        exp = ExperienceSummary(
+            experience_name="토익 930점",
+            experience_group="스펙·증빙형",
+            experience_type="어학",
+        )
+        assert exp.experience_group == "스펙·증빙형"
+
+    def test_experience_type_프로젝트(self):
+        exp = ExperienceSummary(
+            experience_name="AI 챗봇 개발",
+            experience_group="상세 서술형",
+            experience_type="프로젝트",
+        )
+        assert exp.experience_type == "프로젝트"
+
+    def test_experience_type_어학(self):
+        exp = ExperienceSummary(
+            experience_name="TOEIC 900",
+            experience_group="스펙·증빙형",
+            experience_type="어학",
+        )
+        assert exp.experience_type == "어학"
+
+    def test_experience_type_인턴(self):
+        exp = ExperienceSummary(
+            experience_name="네이버 인턴십",
+            experience_group="상세 서술형",
+            experience_type="인턴/직무경험",
+        )
+        assert exp.experience_type == "인턴/직무경험"
+
+    def test_missing_required_field_raises(self):
+        with pytest.raises(ValidationError):
+            ExperienceSummary(
+                experience_name="missing group and type",
+            )
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# 작업 3: Step2ExtractedExperience 파싱
+# ──────────────────────────────────────────────────────────────────────────────
+
+def _project_basic_info_dict():
+    return {
+        "project_name": "AI 추천 시스템",
+        "period": "2023.03 - 2023.08",
+        "role": "백엔드 개발",
+        "organization": "부산대학교 캡스톤팀",
+        "achievements": "추천 정확도 15% 향상",
+    }
+
+
+class TestStep2ExtractedExperience:
+    def _base_step2_dict(self, **overrides):
+        data = {
+            "experience_name": "AI 추천 시스템 개발",
+            "experience_group": "상세 서술형",
+            "experience_type": "프로젝트",
+            "basic_info": _project_basic_info_dict(),
+        }
+        data.update(overrides)
+        return data
+
+    def test_needs_merge_true_includes_merge_fields(self):
+        data = self._base_step2_dict(
+            needs_merge=True,
+            merge_candidate_id="exp-001",
+            merge_similarity=0.91,
+        )
+        exp = Step2ExtractedExperience(**data)
+        assert exp.needs_merge is True
+        assert exp.merge_candidate_id == "exp-001"
+        assert exp.merge_similarity == pytest.approx(0.91)
+
+    def test_needs_merge_false_merge_fields_default_none(self):
+        data = self._base_step2_dict(needs_merge=False)
+        exp = Step2ExtractedExperience(**data)
+        assert exp.needs_merge is False
+        assert exp.merge_candidate_id is None
+        assert exp.merge_similarity is None
+
+    def test_basic_info_project_info_parsed(self):
+        """normalize_basic_info_after_validation이 dict를 반환하므로 basic_info는 dict 타입이다."""
+        data = self._base_step2_dict()
+        exp = Step2ExtractedExperience(**data)
+        assert isinstance(exp.basic_info, dict)
+        assert exp.basic_info["project_name"] == "AI 추천 시스템"
+        assert exp.basic_info["role"] == "백엔드 개발"
+
+    def test_basic_info_project_info_from_dict(self):
+        """basic_info를 dict로 넘겨도 정규화 후 dict로 파싱된다."""
+        data = self._base_step2_dict(
+            basic_info={
+                "project_name": "딥러닝 모델 최적화",
+                "period": "2024.01 - 2024.06",
+                "role": "ML 엔지니어",
+                "organization": "연구실",
+                "achievements": "추론 속도 30% 개선",
+            }
+        )
+        exp = Step2ExtractedExperience(**data)
+        assert isinstance(exp.basic_info, dict)
+        assert exp.basic_info["project_name"] == "딥러닝 모델 최적화"
+
+    def test_keywords_defaults_to_empty_list(self):
+        data = self._base_step2_dict()
+        exp = Step2ExtractedExperience(**data)
+        assert exp.keywords == []
+
+    def test_is_important_defaults_false(self):
+        data = self._base_step2_dict()
+        exp = Step2ExtractedExperience(**data)
+        assert exp.is_important is False
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# 작업 4: JobPostingBase 전체 구조 파싱
+# ──────────────────────────────────────────────────────────────────────────────
+
+class TestJobPostingBaseFull:
+    def test_full_structure_with_sections_processes_documents(self):
+        data = {
+            "company_name": "카카오",
+            "notice_name": "2024 하반기 신입공채",
+            "category": "FULL_TIME",
+            "employment_type": "정규직",
+            "started_at": "2024-09-01T09:00:00",
+            "ended_at": "2024-09-30T23:59:59",
+            "notice_url": "https://kakao.com/careers/notice/1",
+            "headcount": "00명",
+            "region_1depth": "경기",
+            "workplace_address": "경기도 성남시 분당구",
+            "sections": [
+                {
+                    "section_name": "개발 부문",
+                    "job_title": "백엔드 개발자",
+                    "responsibilities": "서버 개발 및 유지보수",
+                    "workplace": "판교",
+                    "headcount": "10명",
+                    "qualifications": [
+                        {
+                            "general_qualification": "컴퓨터공학 학사 이상",
+                            "mandatory_qualification": None,
+                        }
+                    ],
+                    "preferences": [
+                        {
+                            "general_preference": "Python 유경험자",
+                        }
+                    ],
+                }
+            ],
+            "processes": [
+                {
+                    "process_name": "공통 전형",
+                    "document_screen_schedule": "2024-10-01",
+                    "application_period": "2024-09-01 ~ 2024-09-30",
+                }
+            ],
+            "documents": [
+                {
+                    "mandatory_documents": "이력서, 자소서",
+                    "apply_method": "온라인",
+                    "apply_url_or_email": "https://kakao.com/apply",
+                }
+            ],
+            "citations": [],
+        }
+        job = JobPostingBase(**data)
+        assert job.company_name == "카카오"
+        assert job.headcount == "00명"
+        assert len(job.sections) == 1
+        assert job.sections[0].section_name == "개발 부문"
+        assert job.sections[0].headcount == "10명"
+        assert len(job.sections[0].qualifications) == 1
+        assert len(job.processes) == 1
+        assert job.processes[0].process_name == "공통 전형"
+        assert len(job.documents) == 1
+        assert job.documents[0].apply_method == "온라인"
+
+    def test_sections_defaults_to_empty_list(self):
+        data = _base_job_posting_dict()
+        job = JobPostingBase(**data)
+        assert job.sections == []
+        assert job.processes == []
+        assert job.documents == []
+        assert job.citations == []
+
+    def test_missing_required_company_name_raises(self):
+        data = {
+            "notice_name": "공채",
+            "category": "FULL_TIME",
+            "started_at": "2024-09-01T00:00:00",
+        }
+        with pytest.raises(ValidationError):
+            JobPostingBase(**data)


### PR DESCRIPTION
## 관련 이슈
- #35
- Base: `main`

## 문제
1. **headcount 타입 불일치**: AI 스크래핑 결과는 `"00명 내외"` 같은 문자열이지만 `JobPostingBase.headcount`가 `Optional[int]`로 선언되어 있어 BE와 계약이 어긋남
2. **async 엔드포인트에서 sync 서비스 직접 호출**: FastAPI async 핸들러 내부에서 blocking I/O(LLM 호출, 임베딩 API 등)를 동기로 호출해 이벤트 루프를 점유, 동시 요청 처리 성능 저하
3. **sequential merge 비효율**: `apply_sequential_merge_results_to_step2`가 루프마다 `_embed_texts` (OpenAI API)를 호출해 경험 N개 기준 API가 N번 발생

## 작업 내용
- `job_dto.py`: `headcount` 타입 `Optional[int]` → `Optional[str]` 변경
- `router.py`: 모든 async 엔드포인트의 sync 서비스 호출을 `asyncio.to_thread()` 로 래핑
  - `analyze_url`, `analyze_pdf`, `analyze_image`, `extract_experiences`, `extract_experiences_step1`, `extract_experiences_step2`, `check_experience_merge`, `analyze_and_place`
- `experience_extraction_v2.py`: step2-v2 엔드포인트 서비스 호출도 동일하게 래핑
- `experience_merge_service.py`: `apply_sequential_merge_results_to_step2` 전체 텍스트 임베딩 1회로 최적화 (N회 → 1회)
- `pytest.ini`: `pythonpath = .` 추가로 테스트 모듈 경로 문제 해결
- `tests/test_schemas.py`: headcount 타입 및 `Step2ExtractedExperience.basic_info` 파싱 동작 검증 (21개 케이스)

## 테스트
- `pytest tests/test_schemas.py -v` → 21개 전체 통과